### PR TITLE
always start without the artifacts folder

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -5,3 +5,4 @@ set -ex
 echo "[Docker Control Plugin] - Skipping git checkout"
 
 git clean -ffxdq || true
+git rm -rf artifacts


### PR DESCRIPTION
ensures that we start from a clean slate