### PR TITLE
Upload docker-compose logs as an artifact instead

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -7,7 +7,7 @@ IMAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_IMAGE
 
 if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
 echo "~~~ :docker: docker-control service logs" >&2
-  docker-compose -f $COMPOSE_FILE logs --tail="all"
+  docker-compose -f $COMPOSE_FILE logs --tail="all" | buildkite-agent artifact upload
 fi
 
 # Try to spin down services

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -7,7 +7,8 @@ IMAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_IMAGE
 
 if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
 echo "~~~ :docker: docker-control service logs" >&2
-  docker-compose -f $COMPOSE_FILE logs --tail="all" | buildkite-agent artifact upload
+  docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
+  buildkite-agent artifact upload docker-compose-logs.txt
 fi
 
 # Try to spin down services


### PR DESCRIPTION
Buildkite has a 1MB streaming limit, so uploading verbose docker-compose logs as an artifact instead of stdout stream will help keep us under that limit.