### PR TITLE
Chmod artifact folders to 777

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -43,8 +43,11 @@ CMD
 # copy contents of web-code-source to the working directory
 cp -a web-code-source/* .
 
+# Update artifact folders for web-code.
 chmod -R 777 "artifacts" || true
 chmod -R 777 "${PACKAGE}/artifacts" || true
+rm "artifacts/.gitignore" || true
+rm "${PACKAGE}/artifacts/.gitignore" || true
 
 # download artifact, if specified
 if [ -n "$ARTIFACT_DOWNLOAD" ]; then

--- a/hooks/command
+++ b/hooks/command
@@ -43,6 +43,9 @@ CMD
 # copy contents of web-code-source to the working directory
 cp -a web-code-source/* .
 
+chmod -R 777 "artifacts" || true
+chmod -R 777 "${PACKAGE}/artifacts" || true
+
 # download artifact, if specified
 if [ -n "$ARTIFACT_DOWNLOAD" ]; then
   echo "--- :arrow_heading_down: downloading artifacts ${ARTIFACT_DOWNLOAD}"


### PR DESCRIPTION
Writing to artifact folders in puppeteer requires them to be chmodded to 777.