### PR TITLE
Make artifacts folder writable for web-code pipeline

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -73,7 +73,7 @@ CMD
 # copy contents of web-code-source to the working directory
 cp -a web-code-source/* .
 
-if [ "$BUILDKITE_PIPELINE_NAME" = "web-code-runner" ]; then
+if [ "$BUILDKITE_PIPELINE_NAME" = "web-code-runner" ] || [ "$BUILDKITE_PIPELINE_NAME" = "web-code" ]; then
   # Update artifact folders for web-code.
   chmod -R 777 "artifacts" || true
   chmod -R 777 "${PACKAGE}/artifacts" || true


### PR DESCRIPTION
Our web-code pipeline utilizes artifacts folders as well, and to use them as an unprivileged user we need to chmod the folder. Whitelist the web-code pipeline for chmodding.