### PR TITLE
Kill docker containers instead of docker-compose service

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -45,7 +45,7 @@ echo "Running ${CMD} for ${PACKAGE} in ${IMAGE}"
 mkdir -p web-code-source && chmod a+w web-code-source
 
 # Try killing all docker-compose containers to ensure there's no conflicting running containers.
-killall docker-compose || true
+docker kill $(docker ps -q) || true
 
 # pull out ci code and $PACKAGE code from the docker build image, and store in local /web-code-source folder
 echo "Pulling image: $IMAGE"


### PR DESCRIPTION
Docker-compose up will leave dangling containers, but not the actual docker-compose service.