### PR TITLE
Add kill-before-run configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,17 @@ steps:
         # Required properties
         artifact-download: 'artifacts/foo/bar.txt'
 ```
+
+
+### `kill-before-run` (optional)
+
+Kills all running docker containers if true.
+
+```
+steps:
+  - command: path/to/script.sh
+    plugins:
+      - 'uber-workflow/docker-control':
+        # Required properties
+        kill-before-run: true
+```

--- a/hooks/command
+++ b/hooks/command
@@ -9,6 +9,7 @@ IMAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_IMAGE
 COMPOSE_FILE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_COMPOSE_FILE
 SERVICE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_SERVICE
 SHOULD_BUILD=$BUILDKITE_PLUGIN_DOCKER_CONTROL_BUILD
+KILL_BEORE_RUN=$BUILDKITE_PLUGIN_DOCKER_CONTROL_KILL_BEFORE_RUN
 ARTIFACT_DOWNLOAD=$BUILDKITE_PLUGIN_DOCKER_CONTROL_ARTIFACT_DOWNLOAD
 export PACKAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_PACKAGE
 PULL_RETRIES=3
@@ -45,7 +46,9 @@ echo "Running ${CMD} for ${PACKAGE} in ${IMAGE}"
 mkdir -p web-code-source && chmod a+w web-code-source
 
 # Try killing all docker-compose containers to ensure there's no conflicting running containers.
-docker kill $(docker ps -q) || true
+if [ -n "$KILL_BEORE_RUN" ]; then
+  docker kill $(docker ps -q) || true
+fi
 
 # pull out ci code and $PACKAGE code from the docker build image, and store in local /web-code-source folder
 echo "Pulling image: $IMAGE"


### PR DESCRIPTION
This adds a config option in order to prevent killing docker containers. This is necessary in order to run multiple agents on an instance.