### PR TITLE
Fix artifacts to work with remote task pipeline

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -84,11 +84,16 @@ if [ "$BUILDKITE_PIPELINE_NAME" = "web-code-runner" ] || [ "$BUILDKITE_PIPELINE_
   rm "${PACKAGE}/artifacts/.gitignore" || true
 fi
 
+if [ "$BUILDKITE_PIPELINE_NAME" = "web-code-task-runner" ]; then
+  chmod 777 "artifacts" || true
+fi
+
 # download artifact, if specified
 if [ -n "$ARTIFACT_DOWNLOAD" ]; then
   echo "--- :arrow_heading_down: downloading artifacts ${ARTIFACT_DOWNLOAD}"
   set +e
   buildkite-agent artifact download "${ARTIFACT_DOWNLOAD}" .
+  chmod -R 777 $(dirname "${ARTIFACT_DOWNLOAD}")
   if [ $? -ne 0 ]; then
     echo "Artifact ${ARTIFACT_DOWNLOAD} not found. Continuing..."
   fi


### PR DESCRIPTION
While upgrading our remote task pipeline to use the newer base web-code image that uses user`testuser` instead of `root`, I noticed that some artifacts-related code was breaking due to permissions errors. This fixes those permissions errors.

Verified that web-code still works as expected here: https://code.uberinternal.com/D4274403

Verified that web-code-task-runner works as expected here: https://buildkite.com/uber/web-code-task-runner/builds/819

After this lands, I will sync the changes to https://code.uberinternal.com/diffusion/INDOCXF/
