### PR TITLE
use --progress=plain

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -101,7 +101,7 @@ if [ -n "$ARTIFACT_DOWNLOAD" ]; then
 fi
 
 if [ -n "$SHOULD_BUILD" ]; then
-  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 IMAGE=$IMAGE docker-compose $VERBOSE -f $COMPOSE_FILE build $SERVICE
+  COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 IMAGE=$IMAGE docker-compose $VERBOSE -f $COMPOSE_FILE build --progress=plain $SERVICE
 fi
 
 if [ -z $SCRIPT ]


### PR DESCRIPTION
Use the `--progress=plain` flag, so build logs show up normally in CI. Otherwise the CLI output displays in-place in terminals and render improperly in CI.

see https://stackoverflow.com/questions/55756372/when-using-buildkit-with-docker-how-do-i-see-the-output-of-run-commands for more info