### PR TITLE
Catch all other pipelines that may be using artifacts

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -76,7 +76,7 @@ CMD
 # copy contents of web-code-source to the working directory
 cp -a web-code-source/* .
 
-if [ "$BUILDKITE_PIPELINE_NAME" = "web-code-runner" ] || [ "$BUILDKITE_PIPELINE_NAME" = "web-code" ]; then
+if [ ! "$BUILDKITE_PIPELINE_NAME" = "web-code-task-runner" ]; then
   # Update artifact folders for web-code.
   chmod -R 777 "artifacts" || true
   chmod -R 777 "${PACKAGE}/artifacts" || true


### PR DESCRIPTION
Allows other pipelines to use the `artifacts/` directory.  In this specific case, this was causing inconsistencies across our CI and SQ builds.