### PR TITLE
Add post-command hook to upload failure analysis for job

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -9,5 +9,6 @@ fi
 
 echo "~~~ :arrow_double_up: uploading failure analysis to s3"
 
+PIPELINE_SLUG="${BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG:-BUILDKITE_PIPELINE_SLUG}"
 BUILD_ID="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-BUILDKITE_BUILD_ID}"
-aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/build-${BUILD_ID}/job-${BUILDKITE_JOB_ID}/failure"
+aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${PIPELINE_SLUG}/build-${BUILD_ID}/job-${BUILDKITE_JOB_ID}/failure"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,4 +10,4 @@ fi
 echo "~~~ :arrow_double_up: uploading failure analysis to s3"
 
 BUILD_ID="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-BUILDKITE_BUILD_ID}"
-aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${BUILD_ID}/${BUILDKITE_JOB_ID}/failure"
+aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/build-${BUILD_ID}/job-${BUILDKITE_JOB_ID}/failure"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+failure="artifacts/analysis/failure"
+
+# if failure file not present, exit
+if ! ls failure &> /dev/null; then
+  exit 0
+fi
+
+echo "~~~ :arrow_double_up: uploading failure analysis to s3"
+
+BUILD_ID="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-BUILDKITE_BUILD_ID}"
+aws s3 cp failure "s3://uber-web-monorepo/analysis/${BUILD_ID}/${BUILDKITE_JOB_ID}/failure"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -3,11 +3,11 @@
 failure="artifacts/analysis/failure"
 
 # if failure file not present, exit
-if ! ls failure &> /dev/null; then
+if ! ls "$failure" &> /dev/null; then
   exit 0
 fi
 
 echo "~~~ :arrow_double_up: uploading failure analysis to s3"
 
 BUILD_ID="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-BUILDKITE_BUILD_ID}"
-aws s3 cp failure "s3://uber-web-monorepo/analysis/${BUILD_ID}/${BUILDKITE_JOB_ID}/failure"
+aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${BUILD_ID}/${BUILDKITE_JOB_ID}/failure"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,5 +10,5 @@ fi
 echo "~~~ :arrow_double_up: uploading failure analysis to s3"
 
 PIPELINE_SLUG="${BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG:-BUILDKITE_PIPELINE_SLUG}"
-BUILD_ID="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-BUILDKITE_BUILD_ID}"
-aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${PIPELINE_SLUG}/build-${BUILD_ID}/${BUILDKITE_JOB_ID}.failure"
+BUILD_NUMBER="${BUILDKITE_TRIGGERED_FROM_BUILD_NUMBER:-BUILDKITE_BUILD_NUMBER}"
+aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${BUILDKITE_ORGANIZATION_SLUG}/${PIPELINE_SLUG}/build-${BUILD_NUMBER}/${BUILDKITE_JOB_ID}.failure"

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -11,4 +11,4 @@ echo "~~~ :arrow_double_up: uploading failure analysis to s3"
 
 PIPELINE_SLUG="${BUILDKITE_TRIGGERED_FROM_BUILD_PIPELINE_SLUG:-BUILDKITE_PIPELINE_SLUG}"
 BUILD_ID="${BUILDKITE_TRIGGERED_FROM_BUILD_ID:-BUILDKITE_BUILD_ID}"
-aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${PIPELINE_SLUG}/build-${BUILD_ID}/job-${BUILDKITE_JOB_ID}/failure"
+aws s3 cp "$failure" "s3://uber-web-monorepo/analysis/${PIPELINE_SLUG}/build-${BUILD_ID}/${BUILDKITE_JOB_ID}.failure"


### PR DESCRIPTION
Adds failure analysis for a job to s3, indexed by top-level build

<img width="1028" alt="Screen Shot 2020-07-06 at 8 49 27 PM" src="https://user-images.githubusercontent.com/1920766/86704957-3adbbe00-bfca-11ea-85fe-ba277d46c98a.png">

working towards https://docs.google.com/document/d/1UCZLjsSQJND5ddbJCcKUKV4dVYCWcNXN-mbM4jtdgfc/edit
