### PR TITLE
Add abort-on-container-exit

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -107,7 +107,8 @@ fi
 if [ -z $SCRIPT ]
 then
   echo "+++ :docker: docker-control run" >&2
-  IMAGE=$IMAGE docker-compose $VERBOSE -f $COMPOSE_FILE run --rm $SERVICE
+  IMAGE=$IMAGE docker-compose $VERBOSE -f $COMPOSE_FILE up --abort-on-container-exit $SERVICE
+  docker-compose stop
 else
   echo "+++ :docker: docker-control run" >&2
   IMAGE=$IMAGE docker-compose $VERBOSE -f $COMPOSE_FILE run --rm $SERVICE bash $SCRIPT


### PR DESCRIPTION
This requires that we use `docker-compose up` instead of `docker-compose run` in order to add this flag.