### PR TITLE
clean up volumes

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -14,6 +14,6 @@ fi
 # Try to spin down services
 echo "~~~ :docker: docker-control cleanup" >&2
 docker-compose -f $COMPOSE_FILE kill || true
-docker-compose -f $COMPOSE_FILE down || true
+docker-compose -f $COMPOSE_FILE down -v || true
 echo "Removing image ${IMAGE}"
 docker image rm "$IMAGE" || true


### PR DESCRIPTION
Occasionally seeing this docker error:

"... Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type."

Jira issue: https://t3.uberinternal.com/browse/WPT-6873

One of the stackoverflow responses [here](https://stackoverflow.com/questions/45972812/are-you-trying-to-mount-a-directory-onto-a-file-or-vice-versa) suggests that it could be due to a dangling volume that wasn't cleaned up properly

Supplying the `-v` arg to ensure that volumes get removed properly.