### PR TITLE
Prevent docker-compose from exiting 255

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -101,7 +101,12 @@ if [ -n "$ARTIFACT_DOWNLOAD" ]; then
 fi
 
 if [ -n "$SHOULD_BUILD" ]; then
+  set +e
   COMPOSE_DOCKER_CLI_BUILD=1 DOCKER_BUILDKIT=1 IMAGE=$IMAGE docker-compose $VERBOSE -f $COMPOSE_FILE build --progress=plain $SERVICE
+  if [ $? = 255 ]; then
+    exit 1
+  fi
+  set -e
 fi
 
 if [ -z $SCRIPT ]


### PR DESCRIPTION
When there's a failure during the build of the docker image, docker-compose seems to exit with 255 (in linux at least) regardless of the exit code used in the actual failure. This instead will use exit code 1.

Validated in https://code.uberinternal.com/D5066451