### PR TITLE
clean up volumes before job

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -46,6 +46,7 @@ mkdir -p web-code-source && chmod a+w web-code-source
 
 # Try killing all docker-compose containers to ensure there's no conflicting running containers.
 docker kill $(docker ps -q) || true
+docker volume rm $(docker volume ls -q) > /dev/null 2>&1 || true
 
 # pull out ci code and $PACKAGE code from the docker build image, and store in local /web-code-source folder
 echo "Pulling image: $IMAGE"


### PR DESCRIPTION
We can't rely on the pre-exit hook to clean up old docker volumes, because the pre-exit hook does not get run if a job is canceled.

This ensures that docker volumes get cleaned up prior to jobs running, hopefully eliminating this class of errors:
https://buildkite.com/uber/web-code-runner/builds/2838284#77fbcc34-a0b3-4d39-ad05-1f5988905057