### PR TITLE
Add SIGTERM trap for canceled jobs

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -2,43 +2,25 @@
 
 set -eo pipefail
 
+# ignore SIGTERM sent by buildkite when job is canceled to
+# ensure our cleanup always runs
+trap '' SIGTERM
+
 COMPOSE_FILE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_COMPOSE_FILE
 IMAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_IMAGE
 
-FINISHED_LOGS="false"
-FINISHED_CLEANUP="false"
-FINISHED_DISK="false"
+if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
+echo "~~~ :docker: docker-control service logs" >&2
+  docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
+  buildkite-agent artifact upload docker-compose-logs.txt
+fi
 
-function main() {
-  if [ "$FINISHED_LOGS" == "false" ]; then
-    if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
-      echo "uploading docker-control service logs..." >&2
-      docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
-      buildkite-agent artifact upload docker-compose-logs.txt
-    fi
+# Try to spin down services
+echo "~~~ :docker: docker-control cleanup" >&2
+docker-compose -f $COMPOSE_FILE kill || true
+docker-compose -f $COMPOSE_FILE down -v || true
+echo "Removing image ${IMAGE}"
+docker image rm "$IMAGE" || true
 
-    FINISHED_LOGS="true"
-  fi
-
-  if [ "$FINISHED_CLEANUP" == "false" ]; then
-    # Try to spin down services
-    docker-compose -f $COMPOSE_FILE kill || true
-    docker-compose -f $COMPOSE_FILE down -v || true
-    echo "Removing image ${IMAGE}"
-    docker image rm "$IMAGE" || true
-
-    FINISHED_CLEANUP="true"
-  fi
-
-  if [ "$FINISHED_DISK" == "false" ]; then
-    # Log out docker disk usage
-    docker system df
-
-    FINISHED_DISK="true"
-  fi
-}
-
-# if the buildkite job was canceled and SIGTERM was sent,
-# retry running anything that hasn't already
-trap main SIGTERM
-main
+# Log out docker disk usage
+docker system df

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -5,18 +5,40 @@ set -eo pipefail
 COMPOSE_FILE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_COMPOSE_FILE
 IMAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_IMAGE
 
-if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
-echo "~~~ :docker: docker-control service logs" >&2
-  docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
-  buildkite-agent artifact upload docker-compose-logs.txt
-fi
+FINISHED_LOGS="false"
+FINISHED_CLEANUP="false"
+FINISHED_DISK="false"
 
-# Try to spin down services
-echo "~~~ :docker: docker-control cleanup" >&2
-docker-compose -f $COMPOSE_FILE kill || true
-docker-compose -f $COMPOSE_FILE down -v || true
-echo "Removing image ${IMAGE}"
-docker image rm "$IMAGE" || true
+function main() {
+  if [ "$FINISHED_LOGS" == "false" ]; then
+    if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
+      echo "uploading docker-control service logs..." >&2
+      docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
+      buildkite-agent artifact upload docker-compose-logs.txt
+    fi
 
-# Log out docker disk usage
-docker system df
+    FINISHED_LOGS="true"
+  fi
+
+  if [ "$FINISHED_CLEANUP" == "false" ]; then
+    # Try to spin down services
+    docker-compose -f $COMPOSE_FILE kill || true
+    docker-compose -f $COMPOSE_FILE down -v || true
+    echo "Removing image ${IMAGE}"
+    docker image rm "$IMAGE" || true
+
+    FINISHED_CLEANUP="true"
+  fi
+
+  if [ "$FINISHED_DISK" == "false" ]; then
+    # Log out docker disk usage
+    docker system df
+
+    FINISHED_DISK="true"
+  fi
+}
+
+# if the buildkite job was canceled and SIGTERM was sent,
+# retry running anything that hasn't already
+trap main SIGTERM
+main


### PR DESCRIPTION
When a buildkite build is canceled, SIGTERM is sent to jobs after a short period of time, causing it to kill this hook before we can run all our cleanup. This has caused some issues in our CI where subsequent jobs after canceled ones fail to spin up the docker image due to improper cleanup.

This trap, along with the [cancel-grace-period](https://buildkite.com/docs/agent/v3/configuration#configuration-settings) agent option, will ensure this hook has enough time to run everything it needs to, even in canceled jobs.

I confirmed in [a test build](https://buildkite.com/uber/deacy-test/builds/43#a296151f-48fd-4308-8423-e04206bf2fad/94-95) that this has the desired effect