### PR TITLE
Ensure docker-compose file exists before running cleanup

### DIFF
--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eo pipefail
+set -o pipefail
 
 # ignore SIGTERM sent by buildkite when job is canceled to
 # ensure our cleanup always runs
@@ -17,10 +17,10 @@ fi
 
 # Try to spin down services
 echo "~~~ :docker: docker-control cleanup" >&2
-docker-compose -f $COMPOSE_FILE kill || true
-docker-compose -f $COMPOSE_FILE down -v || true
+docker-compose -f $COMPOSE_FILE kill
+docker-compose -f $COMPOSE_FILE down -v
 echo "Removing image ${IMAGE}"
-docker image rm "$IMAGE" || true
+docker image rm "$IMAGE"
 
 # Log out docker disk usage
 docker system df

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -o pipefail
+set -eo pipefail
 
 # ignore SIGTERM sent by buildkite when job is canceled to
 # ensure our cleanup always runs
@@ -9,18 +9,22 @@ trap '' SIGTERM
 COMPOSE_FILE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_COMPOSE_FILE
 IMAGE=$BUILDKITE_PLUGIN_DOCKER_CONTROL_IMAGE
 
-if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
-echo "~~~ :docker: docker-control service logs" >&2
-  docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
-  buildkite-agent artifact upload docker-compose-logs.txt
-fi
+if [ -e "$COMPOSE_FILE" ]; then
+  if [ "$BUILDKITE_PLUGIN_DOCKER_CONTROL_LOGS" == "true" ]; then
+  echo "~~~ :docker: docker-control service logs" >&2
+    docker-compose -f $COMPOSE_FILE logs --tail="all" > docker-compose-logs.txt
+    buildkite-agent artifact upload docker-compose-logs.txt
+  fi
 
-# Try to spin down services
-echo "~~~ :docker: docker-control cleanup" >&2
-docker-compose -f $COMPOSE_FILE kill
-docker-compose -f $COMPOSE_FILE down -v
-echo "Removing image ${IMAGE}"
-docker image rm "$IMAGE"
+  # Try to spin down services
+  echo "~~~ :docker: docker-control cleanup" >&2
+  docker-compose -f $COMPOSE_FILE kill || true
+  docker-compose -f $COMPOSE_FILE down -v || true
+  echo "Removing image ${IMAGE}"
+  docker image rm "$IMAGE" || true
+else
+  echo "${COMPOSE_FILE} not found; skipping cleanup"
+fi
 
 # Log out docker disk usage
 docker system df


### PR DESCRIPTION
We've been noticing this occasionally getting into a weird state when losing an aws instance, where the `docker-compose.yml` file doesn't exist, and the`pre-exit` hook fails, exiting with 1, which overrides the -1 exit code that we use for auto-retry logic.

This checks for that file's existence before running the cleanup